### PR TITLE
test ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,4 @@ Upload videos, upload to panda and R2, embed om player
 - deadletter queue (manual retry)
   - store number of retries and if its the last maybe notice somewhere and display a button for manual retry
 - find possibly typos in transcription based on commit diff
-- setup neon integration vercel to remove github workflows
 - tests please?!


### PR DESCRIPTION
- chore: Remove Github CI due to Neon Vercel integration
- fix: Remove unecessary timeout
- ci: Test Neon Vercel integration
